### PR TITLE
Estimate Next Purchase

### DIFF
--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -73,7 +73,7 @@ export const List = ({ token }) => {
       // update total_purchases by 1
       total_purchases: docData.total_purchases + 1,
       // run updateEstimate helper to update estimated_next_purchase
-      estimated_next_purchase: updateEstimate(),
+      estimated_next_purchase: getEstimate(),
     });
   };
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -31,7 +31,7 @@ export const List = ({ token }) => {
   };
 
   const cleanDate = (date) => {
-    const lastPurchasedDate = moment(date).format('MMMM Do, YYYY');
+    const formattedDate = moment(date).format('MMMM Do, YYYY');
     return lastPurchasedDate;
   };
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -23,7 +23,7 @@ export const List = ({ token }) => {
 
   const calcDaysSince = (transactionDate) => {
     const timeNow = moment().format();
-    const date1 = moment(timeNow, 'YYYYMMDD HH:mm:ss');
+    const date1 = moment();
     const date2 = moment(transactionDate, 'YYYYMMDD HH:mm:ss');
     const timeDiff = date1.diff(date2, 'days');
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -96,6 +96,16 @@ export const List = ({ token }) => {
                 onChange={(e) => handleClick(doc, e)}
               />
               <label htmlFor={doc.id}>{doc.data().item}</label>
+              <p> Total purchases: {doc.data().total_purchases}</p>
+              <p>
+                Last purchased date:
+                {doc.data().last_purchased_date}
+              </p>
+              {doc.data().previous_estimate ? (
+                <p>
+                  Estimated next purchase: {doc.data().previous_estimate} days
+                </p>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -22,7 +22,6 @@ export const List = ({ token }) => {
   };
 
   const calcDaysSince = (transactionDate) => {
-    const timeNow = moment().format();
     const date1 = moment();
     const date2 = moment(transactionDate, 'YYYYMMDD HH:mm:ss');
     const timeDiff = date1.diff(date2, 'days');

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -100,21 +100,21 @@ export const List = ({ token }) => {
                 onChange={(e) => handleClick(doc, e)}
               />
               <label htmlFor={doc.id}>{doc.data().item}</label>
-              {doc.data().total_purchases > 0 ? (
+              {doc.data().total_purchases > 0 && (
                 <p> Total purchases: {doc.data().total_purchases}</p>
-              ) : null}
-              {doc.data().last_purchased_date ? (
+              )}
+              {doc.data().last_purchased_date && (
                 <p>
                   Last purchased date:{' '}
                   {cleanDate(doc.data().last_purchased_date)}
                 </p>
-              ) : null}
-              {doc.data().estimated_next_purchase ? (
+              )}
+              {doc.data().estimated_next_purchase && (
                 <p>
                   Estimated next purchase: {doc.data().estimated_next_purchase}{' '}
                   days
                 </p>
-              ) : null}
+              )}
             </li>
           ))}
         </ul>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -30,6 +30,11 @@ export const List = ({ token }) => {
     return timeDiff;
   };
 
+  const cleanDate = (date) => {
+    const lastPurchasedDate = moment(date).format('MMMM Do, YYYY');
+    return lastPurchasedDate;
+  };
+
   const updateDocument = async (id) => {
     const docRef = doc(db, token, id);
     const document = await getDoc(docRef);
@@ -102,7 +107,7 @@ export const List = ({ token }) => {
               {doc.data().last_purchased_date ? (
                 <p>
                   Last purchased date:
-                  {doc.data().last_purchased_date}
+                  {cleanDate(doc.data().last_purchased_date)}
                 </p>
               ) : null}
               {doc.data().estimated_next_purchase ? (

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import db from '../lib/firebase';
 import { collection, doc, updateDoc } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
@@ -30,7 +31,7 @@ export const List = ({ token }) => {
   const handleClick = (data, e) => {
     updateDocument(data.id);
   };
-  
+
   return (
     <div className="welcoming">
       <h1>Smart Shopping List</h1>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import db from '../lib/firebase';
-import { collection, doc, updateDoc } from 'firebase/firestore';
+import { collection, doc, updateDoc, getDoc } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import moment from 'moment';
 
@@ -21,10 +21,26 @@ export const List = ({ token }) => {
     return timeDiff < 24;
   };
 
+  const calcDaysSince = (transactionDate) => {
+    const timeNow = moment().format();
+    const date1 = moment(timeNow, 'YYYYMMDD HH:mm:ss');
+    const date2 = moment(transactionDate, 'YYYYMMDD HH:mm:ss');
+    const timeDiff = date1.diff(date2, 'days');
+
+    return timeDiff;
+  };
+
   const updateDocument = async (id) => {
     const docRef = doc(db, token, id);
+    const document = await getDoc(docRef);
+    let docData;
+    if (document) {
+      docData = document.data();
+      console.log(docData);
+    }
     await updateDoc(docRef, {
       purchased_date: moment().format(),
+      days_since_last_transaction: calcDaysSince(docData.date_added),
     });
   };
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import db from '../lib/firebase';
-import { collection, doc, updateDoc, getDoc } from 'firebase/firestore';
+import { collection, doc, updateDoc } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import moment from 'moment';
 
@@ -34,26 +34,20 @@ export const List = ({ token }) => {
     return formattedDate;
   };
 
-  const updateDocument = async (id) => {
-    const docRef = doc(db, token, id);
-    const document = await getDoc(docRef);
-    let docData;
-    if (document) {
-      docData = document.data();
-      console.log(docData);
-    }
+  const updateDocument = async (document) => {
+    const docRef = doc(db, token, document.id);
+    let docData = document.data();
+
     const getEstimate = () => {
       // helper function to destructure fields for calculateEstimate
-      let prevEstimate;
+      let prevEstimate = undefined;
       const {
         estimated_next_purchase,
         days_since_last_transaction,
         total_purchases,
       } = docData;
-      // if no estimated_next_purchase exists, use 'undefined' in calculateEstimate (cannot save undefined fields in db)
-      estimated_next_purchase
-        ? (prevEstimate = estimated_next_purchase)
-        : (prevEstimate = undefined);
+      // if estimated_next_purchase exists, use in calculateEstimate, otherwise pass as undefined
+      if (estimated_next_purchase) prevEstimate = estimated_next_purchase;
 
       return calculateEstimate(
         prevEstimate,
@@ -77,7 +71,7 @@ export const List = ({ token }) => {
   };
 
   const handleClick = (data, e) => {
-    updateDocument(data.id);
+    updateDocument(data);
   };
 
   return (

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -32,7 +32,7 @@ export const List = ({ token }) => {
 
   const cleanDate = (date) => {
     const formattedDate = moment(date).format('MMMM Do, YYYY');
-    return lastPurchasedDate;
+    return formattedDate;
   };
 
   const updateDocument = async (id) => {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -42,13 +42,13 @@ export const List = ({ token }) => {
       // helper function to destructure fields for calculateEstimate
       let prevEstimate;
       const {
-        previous_estimate,
+        estimated_next_purchase,
         days_since_last_transaction,
         total_purchases,
       } = docData;
-      // if no previous_estimate exists, use 'undefined' in calculateEstimate (cannot save undefined fields in db)
-      previous_estimate
-        ? (prevEstimate = previous_estimate)
+      // if no estimated_next_purchase exists, use 'undefined' in calculateEstimate (cannot save undefined fields in db)
+      estimated_next_purchase
+        ? (prevEstimate = estimated_next_purchase)
         : (prevEstimate = undefined);
 
       return calculateEstimate(
@@ -67,8 +67,8 @@ export const List = ({ token }) => {
       last_purchased_date: moment().format(),
       // update total_purchases by 1
       total_purchases: docData.total_purchases + 1,
-      // run updateEstimate helper to update previous_estimate
-      previous_estimate: updateEstimate(),
+      // run updateEstimate helper to update estimated_next_purchase
+      estimated_next_purchase: updateEstimate(),
     });
   };
 
@@ -96,14 +96,19 @@ export const List = ({ token }) => {
                 onChange={(e) => handleClick(doc, e)}
               />
               <label htmlFor={doc.id}>{doc.data().item}</label>
-              <p> Total purchases: {doc.data().total_purchases}</p>
-              <p>
-                Last purchased date:
-                {doc.data().last_purchased_date}
-              </p>
-              {doc.data().previous_estimate ? (
+              {doc.data().total_purchases > 0 ? (
+                <p> Total purchases: {doc.data().total_purchases}</p>
+              ) : null}
+              {doc.data().last_purchased_date ? (
                 <p>
-                  Estimated next purchase: {doc.data().previous_estimate} days
+                  Last purchased date:
+                  {doc.data().last_purchased_date}
+                </p>
+              ) : null}
+              {doc.data().estimated_next_purchase ? (
+                <p>
+                  Estimated next purchase: {doc.data().estimated_next_purchase}
+                  days
                 </p>
               ) : null}
             </li>

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -43,7 +43,7 @@ export const List = ({ token }) => {
       docData = document.data();
       console.log(docData);
     }
-    const updateEstimate = () => {
+    const getEstimate = () => {
       // helper function to destructure fields for calculateEstimate
       let prevEstimate;
       const {

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -106,13 +106,13 @@ export const List = ({ token }) => {
               ) : null}
               {doc.data().last_purchased_date ? (
                 <p>
-                  Last purchased date:
+                  Last purchased date:{' '}
                   {cleanDate(doc.data().last_purchased_date)}
                 </p>
               ) : null}
               {doc.data().estimated_next_purchase ? (
                 <p>
-                  Estimated next purchase: {doc.data().estimated_next_purchase}
+                  Estimated next purchase: {doc.data().estimated_next_purchase}{' '}
                   days
                 </p>
               ) : null}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,52 @@
+import moment from 'moment';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
+
 export const sanitize = (input) => {
   const lowerCase = input.toLowerCase();
   return lowerCase.trim();
+};
+
+export const formatDate = (date) => {
+  const formattedDate = moment(date).format('MMMM Do, YYYY');
+  return formattedDate;
+};
+
+export const calcTimeDiff = (purchasedTime) => {
+  const timeNow = moment().format();
+  const date1 = moment(timeNow, 'YYYYMMDD HH:mm:ss');
+  const date2 = moment(purchasedTime, 'YYYYMMDD HH:mm:ss');
+  const timeDiff = date1.diff(date2, 'hours');
+
+  return timeDiff < 24;
+};
+
+export const calcDaysSince = (transactionDate) => {
+  const date1 = moment();
+  const date2 = moment(transactionDate, 'YYYYMMDD HH:mm:ss');
+  const timeDiff = date1.diff(date2, 'days');
+
+  return timeDiff;
+};
+
+export const getEstimate = (data) => {
+  // helper function to destructure fields for calculateEstimate
+  const {
+    date_added,
+    last_purchased_date,
+    estimated_next_purchase,
+    total_purchases,
+  } = data;
+  // if estimated_next_purchase exists, use in calculateEstimate, otherwise pass as undefined
+  let prevEstimate = undefined;
+  if (estimated_next_purchase) prevEstimate = estimated_next_purchase;
+
+  const daysSinceLastTransaction = calcDaysSince(
+    last_purchased_date || date_added,
+  );
+
+  return calculateEstimate(
+    prevEstimate,
+    daysSinceLastTransaction,
+    total_purchases,
+  );
 };

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -50,7 +50,7 @@ export const AddItemView = ({ token }) => {
       const docRef = await addDoc(collection(db, token), {
         item: inputs.item,
         days: parseInt(inputs.days),
-        purchased_date: inputs.last_purchased_date,
+        last_purchased_date: inputs.last_purchased_date,
         date_added: moment().format(),
         previous_estimate: null,
         days_since_last_transaction: null,

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -52,7 +52,7 @@ export const AddItemView = ({ token }) => {
         days: parseInt(inputs.days),
         last_purchased_date: inputs.last_purchased_date,
         date_added: moment().format(),
-        previous_estimate: null,
+        estimated_next_purchase: null,
         days_since_last_transaction: null,
         total_purchases: 0,
       });

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -4,6 +4,7 @@ import { collection, addDoc, getDocs } from 'firebase/firestore';
 import AddItemForm from '../components/AddItemForm';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import moment from 'moment';
 
 export const AddItemView = ({ token }) => {
   const [inputs, setInputs] = useState({
@@ -50,6 +51,10 @@ export const AddItemView = ({ token }) => {
         item: inputs.item,
         days: parseInt(inputs.days),
         purchased_date: inputs.last_purchased_date,
+        date_added: moment().format(),
+        previous_estimate: null,
+        days_since_last_transaction: null,
+        total_purchases: 0,
       });
       setInputs((prevState) => ({ ...prevState, item: '' }));
       console.log('Document written with ID: ', docRef.id);

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -53,7 +53,6 @@ export const AddItemView = ({ token }) => {
         last_purchased_date: inputs.last_purchased_date,
         date_added: moment().format(),
         estimated_next_purchase: null,
-        days_since_last_transaction: null,
         total_purchases: 0,
       });
       setInputs((prevState) => ({ ...prevState, item: '' }));


### PR DESCRIPTION
## Description
In this pull request, we estimate the days until the next purchase.

_Data flow_

1. When the user marks an item as purchased, 
2. updateDocument() is fired (which in addition to setting the purchased date, now called last_purchased_date),
3. increments the total_purchases field, 
4. stores a days_since_last_transaction, and estimated_next_purchase field by calling updateEstimate(),
5. triggering the calculateEstimate() imported with the new data points.

_Firestore database updated schema_

![Screen Shot 2022-02-10 at 3 30 38 PM](https://user-images.githubusercontent.com/67841237/153491572-4c32d462-c171-488a-b3d7-dede5d107a4e.png)



<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

Closes #10 

## Acceptance Criteria

- [X] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database
- [X] The script calculateEstimate from @the-collab-lab/shopping-list-utils should be used to calculate the next estimated purchase interval. 

 <!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |
|✓ | :link: Update dependencies |


## calculateEstimate

[calculateEstimate](https://github.com/the-collab-lab/shopping-list-utils/blob/main/src/calculateEstimate/index.ts)

_Deep dive into how the imported function estimates the next purchase date._


<!-- If UI feature, take provide screenshots -->

### Video Walkthrough

https://user-images.githubusercontent.com/67841237/153494694-01ddade3-fa0e-45d9-8fc0-54753634c59f.mp4


<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
1. `git checkout dp-rb-estimate-purchase` Checkout the branch.
2. `npm install` (we added the calculateEstimate package)
3.  `npm start` (fire up the server)
4. Join the list with token `nee calm social`
5.  Mark an item purchased, you should expect to see the total purchases increment, last purchase date update, and next purchase date.
6. In order to test if anything is being recalculated, you would need to go into the Firestore database for that list token, find the item, and manipulate the last purchased date to the past, so you can purchase it again. 
[Firestore db](https://console.firebase.google.com/project/tcl-37-smart-shopping-list/firestore/data/~2Faid%20misty%20onus~2FJLJ6WxYxP9bwSleQYcC3)
(See video walkthrough)