### PR TITLE
Sort List by Purchase Estimate

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,27 +50,3 @@ label {
   display: block;
   margin: 15px;
 }
-
-.foo {
-  color: red;
-}
-
-.collection-list {
-  list-style-type: none;
-}
-
-.collection-list label {
-  display: inline;
-  margin: 0;
-}
-
-.collection-list input {
-  width: auto;
-}
-
-.welcoming {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
-}

--- a/src/App.css
+++ b/src/App.css
@@ -50,3 +50,23 @@ label {
   display: block;
   margin: 15px;
 }
+
+.collection-list {
+  list-style-type: none;
+}
+
+.collection-list label {
+  display: inline;
+  margin: 0;
+}
+
+.collection-list input {
+  width: auto;
+}
+
+.welcoming {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import db from '../lib/firebase';
-import { collection, doc, updateDoc } from 'firebase/firestore';
+import { collection, doc, updateDoc, query, orderBy } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import moment from 'moment';
 
@@ -9,7 +9,9 @@ import { getEstimate, calcTimeDiff, formatDate } from '../helpers';
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
-  const [value, loading, error] = useCollection(collection(db, token), {
+  const q = query(collection(db, token), orderBy('estimated_next_purchase'));
+
+  const [value, loading, error] = useCollection(q, {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import db from '../lib/firebase';
 import { collection, doc, updateDoc, query, orderBy } from 'firebase/firestore';
@@ -15,6 +15,17 @@ export const List = ({ token }) => {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
   let [filterText, setFilterText] = useState('');
+  let [items, setItems] = useState([]);
+
+  useEffect(() => {
+    if (value) {
+      let val = value.docs;
+      val = val.map((item) => item.data());
+      setItems(val);
+    }
+  }, [value]);
+
+  console.log(items);
 
   const updateDocument = async (document) => {
     const docRef = doc(db, token, document.id);

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -5,7 +5,12 @@ import { collection, doc, updateDoc, query, orderBy } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import moment from 'moment';
 
-import { getEstimate, calcTimeDiff, formatDate } from '../helpers';
+import {
+  getEstimate,
+  calcTimeDiff,
+  formatDate,
+  calcDaysSince,
+} from '../helpers';
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
@@ -24,6 +29,20 @@ export const List = ({ token }) => {
       setItems(val);
     }
   }, [value]);
+
+  useEffect(() => {
+    const handleActive = (item) => {
+      if (
+        item.total_purchases < 2 ||
+        calcDaysSince(item.last_purchased_date) >
+          item.estimated_next_purchase * 2
+      ) {
+        return false;
+      }
+      return true;
+    };
+    items.map((item) => (item.isActive = handleActive(item)));
+  }, [items]);
 
   console.log(items);
 

--- a/src/components/List.jsx
+++ b/src/components/List.jsx
@@ -41,6 +41,9 @@ export const List = ({ token }) => {
       {value && value.docs.length > 0 ? (
         <ul className="collection-list">
           {value.docs.map((doc) => (
+            /* 
+              Extract below into ListItem component and use doc as prop?
+            */
             <li key={doc.id}>
               <input
                 type="checkbox"

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -14,7 +14,7 @@ import {
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
-  const q = query(collection(db, token), orderBy('estimated_next_purchase'));
+  const q = query(collection(db, token), orderBy('item'));
   const [value, loading, error] = useCollection(q, {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
@@ -29,6 +29,10 @@ export const List = ({ token }) => {
         arr.push({ ...item.data(), id: item.id });
       });
       arr.map((item) => (item.isActive = handleActive(item)));
+      arr.sort(
+        (itemA, itemB) =>
+          itemA.estimated_next_purchase - itemB.estimated_next_purchase,
+      );
       arr.sort(
         (itemA, itemB) => Number(itemB.isActive) - Number(itemA.isActive),
       );

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -42,7 +42,7 @@ export const List = ({ token }) => {
       arr.sort(
         (itemA, itemB) =>
           Number(itemB.isActive) - Number(itemA.isActive) ||
-          itemA.estimated_next_purchase - itemB.estimated_next_purchase ||
+          itemA.daysUntilPurchase - itemB.daysUntilPurchase ||
           itemA.item.localeCompare(itemB.item),
       );
       setItems(arr);
@@ -161,11 +161,11 @@ export const List = ({ token }) => {
                       days
                       <br />
                       Purchase:{' '}
-                      {doc.daysUntilPurchase === 1
+                      {doc.daysUntilPurchase === 0
                         ? 'today'
-                        : doc.daysUntilPurchase < 1
-                        ? `overdue by ${(doc.daysUntilPurchase *= -1)} days`
-                        : `in ${doc.daysUntilPurchase} days`}
+                        : doc.daysUntilPurchase < 0
+                        ? `overdue by ${(doc.daysUntilPurchase *= -1)} day(s)`
+                        : `in ${doc.daysUntilPurchase} day(s)`}
                     </p>
                   )}
                   <button

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -1,54 +1,78 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import db from '../lib/firebase';
+import db from '../../lib/firebase';
 import { collection, doc, updateDoc, query, orderBy } from 'firebase/firestore';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import moment from 'moment';
-
+import './list.css';
 import {
   getEstimate,
   calcTimeDiff,
   formatDate,
   calcDaysSince,
-} from '../helpers';
+} from '../../helpers';
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
   const q = query(collection(db, token), orderBy('estimated_next_purchase'));
-
   const [value, loading, error] = useCollection(q, {
     snapshotListenOptions: { includeMetadataChanges: true },
   });
+
   let [filterText, setFilterText] = useState('');
   let [items, setItems] = useState([]);
 
   useEffect(() => {
     if (value) {
-      let val = value.docs;
-      val = val.map((item) => item.data());
-      setItems(val);
+      let arr = [];
+      value.docs.forEach((item) => {
+        arr.push({ ...item.data(), id: item.id });
+      });
+      arr.map((item) => (item.isActive = handleActive(item)));
+      arr.sort(
+        (itemA, itemB) => Number(itemB.isActive) - Number(itemA.isActive),
+      );
+      setItems(arr);
     }
   }, [value]);
 
-  useEffect(() => {
-    const handleActive = (item) => {
-      if (
-        item.total_purchases < 2 ||
-        calcDaysSince(item.last_purchased_date) >
-          item.estimated_next_purchase * 2
-      ) {
-        return false;
-      }
-      return true;
-    };
-    items.map((item) => (item.isActive = handleActive(item)));
-  }, [items]);
+  const handleActive = (item) => {
+    if (
+      item.total_purchases === 0 ||
+      // check if time elapsed works
+      calcDaysSince(item.last_purchased_date) > item.estimated_next_purchase * 2
+    ) {
+      return false;
+    }
+    return true;
+  };
 
   console.log(items);
 
+  // useEffect(() => {
+  //   const handleActive = (item) => {
+  //     if (
+  //       item.total_purchases < 2 ||
+  //       // check if time elapsed works
+  //       calcDaysSince(item.last_purchased_date) >
+  //         item.estimated_next_purchase * 2 ||
+  //       calcTimeDiff(item.last_purchased_date)
+  //     ) {
+  //       return false;
+  //     }
+  //     return true;
+  //   };
+
+  //   items.map((item) => (item.isActive = handleActive(item)));
+  //   items.sort(
+  //     (itemA, itemB) => Number(itemB.isActive) - Number(itemA.isActive),
+  //   );
+  // }, [items]);
+
   const updateDocument = async (document) => {
     const docRef = doc(db, token, document.id);
-    let docData = document.data();
+    let docData = document;
+    console.log(docData);
 
     // this function runs when user selects item as purchased
     await updateDoc(docRef, {
@@ -69,15 +93,30 @@ export const List = ({ token }) => {
     setFilterText(e.target.value);
   };
 
+  const setColor = (item) => {
+    console.log(item.item);
+    console.log(item.isActive);
+
+    if (!item.isActive) {
+      return 'inactive';
+    } else if (item.estimated_next_purchase <= 7) {
+      return 'soon';
+    } else if (item.estimated_next_purchase < 30) {
+      return 'kinda-soon';
+    } else {
+      return 'not-soon';
+    }
+  };
+
   return (
     <div className="welcoming">
       <h1>Smart Shopping List</h1>
       <strong> Shareable List Token : {token} </strong>
       {error && <strong>Error: {JSON.stringify(error)}</strong>}
       {loading && <span>Collection: Loading...</span>}
-      {value && value.docs.length > 0 ? (
+      {items && items.length > 0 ? (
         <div>
-          <div style={{ marginTop: '1em' }}>
+          <div className="search-field">
             <input
               placeholder="Start typing here..."
               value={filterText}
@@ -91,38 +130,35 @@ export const List = ({ token }) => {
             </button>
           </div>
           <ul className="collection-list">
-            {value.docs
+            {items
               .filter((doc) =>
-                doc
-                  .data()
-                  .item.toLowerCase()
-                  .includes(filterText.toLowerCase()),
+                doc.item.toLowerCase().includes(filterText.toLowerCase()),
               )
               .map((doc) => (
-                <li key={doc.id}>
+                <li key={doc.id} className={`${setColor(doc)}`}>
                   <input
                     type="checkbox"
-                    checked={calcTimeDiff(doc.data().last_purchased_date)}
-                    disabled={calcTimeDiff(doc.data().last_purchased_date)}
+                    checked={calcTimeDiff(doc.last_purchased_date)}
+                    disabled={calcTimeDiff(doc.last_purchased_date)}
                     name={doc.id}
                     id={doc.id}
                     onClick={(e) => handleClick(doc, e)}
                     onChange={(e) => handleClick(doc, e)}
+                    aria-label={setColor(doc)}
                   />
-                  <label htmlFor={doc.id}>{doc.data().item}</label>
-                  {doc.data().total_purchases > 0 && (
-                    <p> Total purchases: {doc.data().total_purchases}</p>
+                  <label htmlFor={doc.id}>{doc.item}</label>
+                  {doc.total_purchases > 0 && (
+                    <p> Total purchases: {doc.total_purchases}</p>
                   )}
-                  {doc.data().last_purchased_date && (
+                  {doc.last_purchased_date && (
                     <p>
-                      Last purchased date:{' '}
-                      {formatDate(doc.data().last_purchased_date)}
+                      Last purchased date: {formatDate(doc.last_purchased_date)}
                     </p>
                   )}
-                  {doc.data().estimated_next_purchase && (
+                  {doc.estimated_next_purchase && (
                     <p>
-                      Estimated next purchase:{' '}
-                      {doc.data().estimated_next_purchase} days
+                      Estimated next purchase: {doc.estimated_next_purchase}{' '}
+                      days
                     </p>
                   )}
                 </li>

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -38,7 +38,7 @@ export const List = ({ token }) => {
 
   const handleActive = (item) => {
     if (
-      item.total_purchases === 0 ||
+      calcTimeDiff(item.last_purchased_date) ||
       // check if time elapsed works
       calcDaysSince(item.last_purchased_date) > item.estimated_next_purchase * 2
     ) {

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -43,35 +43,12 @@ export const List = ({ token }) => {
   const handleActive = (item) => {
     if (
       calcTimeDiff(item.last_purchased_date) ||
-      // check if time elapsed works
       calcDaysSince(item.last_purchased_date) > item.estimated_next_purchase * 2
     ) {
       return false;
     }
     return true;
   };
-
-  console.log(items);
-
-  // useEffect(() => {
-  //   const handleActive = (item) => {
-  //     if (
-  //       item.total_purchases < 2 ||
-  //       // check if time elapsed works
-  //       calcDaysSince(item.last_purchased_date) >
-  //         item.estimated_next_purchase * 2 ||
-  //       calcTimeDiff(item.last_purchased_date)
-  //     ) {
-  //       return false;
-  //     }
-  //     return true;
-  //   };
-
-  //   items.map((item) => (item.isActive = handleActive(item)));
-  //   items.sort(
-  //     (itemA, itemB) => Number(itemB.isActive) - Number(itemA.isActive),
-  //   );
-  // }, [items]);
 
   const updateDocument = async (document) => {
     const docRef = doc(db, token, document.id);
@@ -98,9 +75,6 @@ export const List = ({ token }) => {
   };
 
   const setColor = (item) => {
-    console.log(item.item);
-    console.log(item.isActive);
-
     if (!item.isActive) {
       return 'inactive';
     } else if (item.estimated_next_purchase <= 7) {

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -68,9 +68,7 @@ export const List = ({ token }) => {
   };
 
   const deleteItem = async (document) => {
-    if (
-      window.confirm(`Are you sure you want to delete ${document.data().item}?`)
-    ) {
+    if (window.confirm(`Are you sure you want to delete ${document.item}?`)) {
       await deleteDoc(doc(db, token, document.id));
     }
   };

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -42,8 +42,8 @@ export const List = ({ token }) => {
 
   const handleActive = (item) => {
     if (
-      calcTimeDiff(item.last_purchased_date) ||
-      calcDaysSince(item.last_purchased_date) > item.estimated_next_purchase * 2
+      calcDaysSince(item.last_purchased_date) >
+      item.estimated_next_purchase * 2
     ) {
       return false;
     }

--- a/src/components/List/list.css
+++ b/src/components/List/list.css
@@ -1,0 +1,51 @@
+.search-field {
+  margin-top: 1em;
+  display: flex;
+  justify-content: center;
+}
+
+.search-field input {
+  height: 20px;
+}
+
+.collection-list {
+  list-style-type: none;
+}
+
+.collection-list label {
+  display: inline;
+  margin: 0;
+}
+
+.collection-list li {
+  padding: 5px;
+  border-radius: 5px;
+  margin-bottom: 5px;
+}
+
+.collection-list input {
+  width: auto;
+}
+
+.welcoming {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+}
+
+.inactive {
+  background: #f3f5f7;
+}
+
+.soon {
+  background: #dfffe0;
+}
+
+.kinda-soon {
+  background: #ffffcc;
+}
+
+.not-soon {
+  background: #ffe2e2;
+}

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -48,10 +48,6 @@ export const getEstimate = (data) => {
   if (daysSinceLastTransaction === 0)
     daysSinceLastTransaction = estimated_next_purchase;
 
-  console.log(prevEstimate);
-  console.log(daysSinceLastTransaction);
-  console.log(total_purchases);
-
   return calculateEstimate(
     prevEstimate,
     daysSinceLastTransaction,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -40,9 +40,17 @@ export const getEstimate = (data) => {
   let prevEstimate = undefined;
   if (estimated_next_purchase) prevEstimate = estimated_next_purchase;
 
-  const daysSinceLastTransaction = calcDaysSince(
+  let daysSinceLastTransaction = calcDaysSince(
     last_purchased_date || date_added,
   );
+
+  // If no days have passed, return the user's original guess
+  if (daysSinceLastTransaction === 0)
+    daysSinceLastTransaction = estimated_next_purchase;
+
+  console.log(prevEstimate);
+  console.log(daysSinceLastTransaction);
+  console.log(total_purchases);
 
   return calculateEstimate(
     prevEstimate,

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -49,10 +49,9 @@ export const AddItemView = ({ token }) => {
 
       const docRef = await addDoc(collection(db, token), {
         item: inputs.item,
-        days: parseInt(inputs.days),
         last_purchased_date: inputs.last_purchased_date,
         date_added: moment().format(),
-        estimated_next_purchase: null,
+        estimated_next_purchase: parseInt(inputs.days),
         total_purchases: 0,
       });
       setInputs((prevState) => ({ ...prevState, item: '' }));

--- a/src/pages/ListView.jsx
+++ b/src/pages/ListView.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { List } from '../components/List';
+import { List } from '../components/List/List';
 import { useNavigate } from 'react-router-dom';
 
 export const ListView = ({ token }) => {


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

In this PR, we added a visual element to the shopping list for users to be able to tell which items are slated for purchase in the near future. 

We start by sorting the database query by item name to ensure items are displayed in alphabetical order. On the client side, we take the queried entries, add an isActive field (determined by `handleActive()` helper), then sort them by their estimated next purchase interval (ascending) and whether they are active (inactive items are last). That array of items is stored in state and rendered on the page. Items are color-coded by their categories ['inactive', 'soon', 'kinda-soon', 'not-soon'] which are correlated to the estimated purchase interval using the `setColor` function. These categories are also denoted using an aria-label.

`handleActive()` marks an item as inactive if it is out of date (more than twice the estimated purchase interval has elapsed). 

`getEstimate()` was refactored to use the user-provided purchase estimate to ensure that newly-added items will not have a purchase estimate of 0.

## Related Issue

Closes #12 

## Acceptance Criteria

AC:
- [X] Items in the list are shown as visually distinct (e.g., with a different background color on the list item) according to how soon the item is expected to be bought again: Soon, Kind of soon, Not soon, Inactive
- [X] Items should be sorted by the estimated number of days until the next purchase
- [X] Items with the same number of estimated days until next purchase should be sorted alphabetically
- [X] Items in the different states should be described distinctly when read by a screen reader

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |


## Updates

### Before

![list-before](https://user-images.githubusercontent.com/82783679/154603537-aba8c8e0-773e-4afc-9498-0bd43af0a85d.jpg)


### After


https://user-images.githubusercontent.com/82783679/154606872-cb92a7dc-0903-4d88-9a3d-05d5ae6ab232.mp4

Update to the video: When an item is marked as purchased, it will NOT be inactive. It'll move to the category based on the estimated purchase. 



## Testing Steps / QA Criteria

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->
1. Pull/checkout branch `vd-rb-sort-by-estimate` and run `npm start`
2. Start a new list or join an existing one e.g. `xxxx hello flam`
3. Items should be sorted and color-coded according to estimated next purchase. Items with same estimated interval should be sorted alphabetically.
4. If an item is marked as purchased, it will either remain in its same category or move if the estimated purchase changes.
5. If you manipulate the item's last purchased date so that 2x the estimated purchase interval has elapsed, the item should become inactive.
