### PR TITLE
Add Page Wrapper to Internal Pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,26 +1,3 @@
-.App {
-  margin-left: 50px;
-}
-
-.App-logo {
-  height: 40vmin;
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #09d3ac;
-}
-
 .bold {
   font-weight: bold;
   margin-left: 30px;
@@ -62,13 +39,6 @@ label {
 
 .collection-list input {
   width: auto;
-}
-
-.welcoming {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  align-items: center;
 }
 
 .delete-button {

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -17,7 +17,6 @@ import {
   formatDate,
   calcDaysSince,
 } from '../../helpers';
-import { PageWrapper } from '../PageWrapper/PageWrapper';
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
@@ -110,86 +109,83 @@ export const List = ({ token }) => {
   };
 
   return (
-    <PageWrapper>
-      <div className="welcoming">
-        <h1>Smart Shopping List</h1>
-        <strong> Shareable List Token : {token} </strong>
-        {error && <strong>Error: {JSON.stringify(error)}</strong>}
-        {loading && <span>Collection: Loading...</span>}
-        {items && items.length > 0 ? (
-          <div>
-            <div className="search-field">
-              <input
-                placeholder="Start typing here..."
-                value={filterText}
-                onChange={handleFilterChange}
-              />
-              <button
-                style={{ marginLeft: '10px' }}
-                onClick={() => setFilterText('')}
-              >
-                X
-              </button>
-            </div>
-            <ul className="collection-list">
-              {items
-                .filter((doc) =>
-                  doc.item.toLowerCase().includes(filterText.toLowerCase()),
-                )
-                .map((doc) => (
-                  <li key={doc.id} className={getCategory(doc)}>
-                    <input
-                      type="checkbox"
-                      checked={calcTimeDiff(doc.last_purchased_date)}
-                      disabled={calcTimeDiff(doc.last_purchased_date)}
-                      name={doc.id}
-                      id={doc.id}
-                      onClick={(e) => handleClick(doc, e)}
-                      onChange={(e) => handleClick(doc, e)}
-                      aria-label={getCategory(doc)}
-                    />
-                    <label htmlFor={doc.id}>{doc.item}</label>
-                    {doc.total_purchases > 0 && (
-                      <p> Total purchases: {doc.total_purchases}</p>
-                    )}
-                    {doc.last_purchased_date && (
-                      <p>
-                        Last purchased date:{' '}
-                        {formatDate(doc.last_purchased_date)}
-                      </p>
-                    )}
-                    {doc.estimated_next_purchase && (
-                      <p>
-                        Estimated next purchase: {doc.estimated_next_purchase}{' '}
-                        days
-                        <br />
-                        Purchase:{' '}
-                        {doc.daysUntilPurchase === 0
-                          ? 'today'
-                          : doc.daysUntilPurchase < 0
-                          ? `overdue by ${(doc.daysUntilPurchase *= -1)} day(s)`
-                          : `in ${doc.daysUntilPurchase} day(s)`}
-                      </p>
-                    )}
-                    <button
-                      className="delete-button"
-                      onClick={() => deleteItem(doc)}
-                    >
-                      delete
-                    </button>
-                  </li>
-                ))}
-            </ul>
-          </div>
-        ) : (
-          <div>
-            <p>Your shopping list is currently empty.</p>
-            <button type="button" onClick={() => navigate('/add')}>
-              ADD YOUR FIRST ITEM
+    <div className="welcoming">
+      <h1>Smart Shopping List</h1>
+      <strong> Shareable List Token : {token} </strong>
+      {error && <strong>Error: {JSON.stringify(error)}</strong>}
+      {loading && <span>Collection: Loading...</span>}
+      {items && items.length > 0 ? (
+        <div>
+          <div className="search-field">
+            <input
+              placeholder="Start typing here..."
+              value={filterText}
+              onChange={handleFilterChange}
+            />
+            <button
+              style={{ marginLeft: '10px' }}
+              onClick={() => setFilterText('')}
+            >
+              X
             </button>
           </div>
-        )}
-      </div>
-    </PageWrapper>
+          <ul className="collection-list">
+            {items
+              .filter((doc) =>
+                doc.item.toLowerCase().includes(filterText.toLowerCase()),
+              )
+              .map((doc) => (
+                <li key={doc.id} className={getCategory(doc)}>
+                  <input
+                    type="checkbox"
+                    checked={calcTimeDiff(doc.last_purchased_date)}
+                    disabled={calcTimeDiff(doc.last_purchased_date)}
+                    name={doc.id}
+                    id={doc.id}
+                    onClick={(e) => handleClick(doc, e)}
+                    onChange={(e) => handleClick(doc, e)}
+                    aria-label={getCategory(doc)}
+                  />
+                  <label htmlFor={doc.id}>{doc.item}</label>
+                  {doc.total_purchases > 0 && (
+                    <p> Total purchases: {doc.total_purchases}</p>
+                  )}
+                  {doc.last_purchased_date && (
+                    <p>
+                      Last purchased date: {formatDate(doc.last_purchased_date)}
+                    </p>
+                  )}
+                  {doc.estimated_next_purchase && (
+                    <p>
+                      Estimated next purchase: {doc.estimated_next_purchase}{' '}
+                      days
+                      <br />
+                      Purchase:{' '}
+                      {doc.daysUntilPurchase === 0
+                        ? 'today'
+                        : doc.daysUntilPurchase < 0
+                        ? `overdue by ${(doc.daysUntilPurchase *= -1)} day(s)`
+                        : `in ${doc.daysUntilPurchase} day(s)`}
+                    </p>
+                  )}
+                  <button
+                    className="delete-button"
+                    onClick={() => deleteItem(doc)}
+                  >
+                    delete
+                  </button>
+                </li>
+              ))}
+          </ul>
+        </div>
+      ) : (
+        <div>
+          <p>Your shopping list is currently empty.</p>
+          <button type="button" onClick={() => navigate('/add')}>
+            ADD YOUR FIRST ITEM
+          </button>
+        </div>
+      )}
+    </div>
   );
 };

--- a/src/components/List/List.jsx
+++ b/src/components/List/List.jsx
@@ -17,6 +17,7 @@ import {
   formatDate,
   calcDaysSince,
 } from '../../helpers';
+import { PageWrapper } from '../PageWrapper/PageWrapper';
 
 export const List = ({ token }) => {
   let navigate = useNavigate();
@@ -109,83 +110,86 @@ export const List = ({ token }) => {
   };
 
   return (
-    <div className="welcoming">
-      <h1>Smart Shopping List</h1>
-      <strong> Shareable List Token : {token} </strong>
-      {error && <strong>Error: {JSON.stringify(error)}</strong>}
-      {loading && <span>Collection: Loading...</span>}
-      {items && items.length > 0 ? (
-        <div>
-          <div className="search-field">
-            <input
-              placeholder="Start typing here..."
-              value={filterText}
-              onChange={handleFilterChange}
-            />
-            <button
-              style={{ marginLeft: '10px' }}
-              onClick={() => setFilterText('')}
-            >
-              X
+    <PageWrapper>
+      <div className="welcoming">
+        <h1>Smart Shopping List</h1>
+        <strong> Shareable List Token : {token} </strong>
+        {error && <strong>Error: {JSON.stringify(error)}</strong>}
+        {loading && <span>Collection: Loading...</span>}
+        {items && items.length > 0 ? (
+          <div>
+            <div className="search-field">
+              <input
+                placeholder="Start typing here..."
+                value={filterText}
+                onChange={handleFilterChange}
+              />
+              <button
+                style={{ marginLeft: '10px' }}
+                onClick={() => setFilterText('')}
+              >
+                X
+              </button>
+            </div>
+            <ul className="collection-list">
+              {items
+                .filter((doc) =>
+                  doc.item.toLowerCase().includes(filterText.toLowerCase()),
+                )
+                .map((doc) => (
+                  <li key={doc.id} className={getCategory(doc)}>
+                    <input
+                      type="checkbox"
+                      checked={calcTimeDiff(doc.last_purchased_date)}
+                      disabled={calcTimeDiff(doc.last_purchased_date)}
+                      name={doc.id}
+                      id={doc.id}
+                      onClick={(e) => handleClick(doc, e)}
+                      onChange={(e) => handleClick(doc, e)}
+                      aria-label={getCategory(doc)}
+                    />
+                    <label htmlFor={doc.id}>{doc.item}</label>
+                    {doc.total_purchases > 0 && (
+                      <p> Total purchases: {doc.total_purchases}</p>
+                    )}
+                    {doc.last_purchased_date && (
+                      <p>
+                        Last purchased date:{' '}
+                        {formatDate(doc.last_purchased_date)}
+                      </p>
+                    )}
+                    {doc.estimated_next_purchase && (
+                      <p>
+                        Estimated next purchase: {doc.estimated_next_purchase}{' '}
+                        days
+                        <br />
+                        Purchase:{' '}
+                        {doc.daysUntilPurchase === 0
+                          ? 'today'
+                          : doc.daysUntilPurchase < 0
+                          ? `overdue by ${(doc.daysUntilPurchase *= -1)} day(s)`
+                          : `in ${doc.daysUntilPurchase} day(s)`}
+                      </p>
+                    )}
+                    <button
+                      className="delete-button"
+                      onClick={() => deleteItem(doc)}
+                    >
+                      delete
+                    </button>
+                  </li>
+                ))}
+            </ul>
+          </div>
+        ) : (
+          <div>
+            <p>Your shopping list is currently empty.</p>
+            <button type="button" onClick={() => navigate('/add')}>
+              ADD YOUR FIRST ITEM
             </button>
           </div>
-          <ul className="collection-list">
-            {items
-              .filter((doc) =>
-                doc.item.toLowerCase().includes(filterText.toLowerCase()),
-              )
-              .map((doc) => (
-                <li key={doc.id} className={getCategory(doc)}>
-                  <input
-                    type="checkbox"
-                    checked={calcTimeDiff(doc.last_purchased_date)}
-                    disabled={calcTimeDiff(doc.last_purchased_date)}
-                    name={doc.id}
-                    id={doc.id}
-                    onClick={(e) => handleClick(doc, e)}
-                    onChange={(e) => handleClick(doc, e)}
-                    aria-label={getCategory(doc)}
-                  />
-                  <label htmlFor={doc.id}>{doc.item}</label>
-                  {doc.total_purchases > 0 && (
-                    <p> Total purchases: {doc.total_purchases}</p>
-                  )}
-                  {doc.last_purchased_date && (
-                    <p>
-                      Last purchased date: {formatDate(doc.last_purchased_date)}
-                    </p>
-                  )}
-                  {doc.estimated_next_purchase && (
-                    <p>
-                      Estimated next purchase: {doc.estimated_next_purchase}{' '}
-                      days
-                      <br />
-                      Purchase:{' '}
-                      {doc.daysUntilPurchase === 0
-                        ? 'today'
-                        : doc.daysUntilPurchase < 0
-                        ? `overdue by ${(doc.daysUntilPurchase *= -1)} day(s)`
-                        : `in ${doc.daysUntilPurchase} day(s)`}
-                    </p>
-                  )}
-                  <button
-                    className="delete-button"
-                    onClick={() => deleteItem(doc)}
-                  >
-                    delete
-                  </button>
-                </li>
-              ))}
-          </ul>
-        </div>
-      ) : (
-        <div>
-          <p>Your shopping list is currently empty.</p>
-          <button type="button" onClick={() => navigate('/add')}>
-            ADD YOUR FIRST ITEM
-          </button>
-        </div>
-      )}
-    </div>
+        )}
+      </div>
+    </PageWrapper>
   );
 };

--- a/src/components/List/list.css
+++ b/src/components/List/list.css
@@ -10,6 +10,7 @@
 
 .collection-list {
   list-style-type: none;
+  padding: 0;
 }
 
 .collection-list label {

--- a/src/components/PageWrapper/PageWrapper.jsx
+++ b/src/components/PageWrapper/PageWrapper.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import './page-wrapper.css';
+
+export const PageWrapper = ({ children }) => {
+  return <div className="wrapper">{children}</div>;
+};

--- a/src/components/PageWrapper/PageWrapper.jsx
+++ b/src/components/PageWrapper/PageWrapper.jsx
@@ -2,5 +2,9 @@ import React from 'react';
 import './page-wrapper.css';
 
 export const PageWrapper = ({ children }) => {
-  return <div className="wrapper">{children}</div>;
+  return (
+    <div className="green-bg">
+      <div className="wrapper">{children}</div>
+    </div>
+  );
 };

--- a/src/components/PageWrapper/page-wrapper.css
+++ b/src/components/PageWrapper/page-wrapper.css
@@ -1,0 +1,5 @@
+.wrapper {
+  border: 1px solid;
+  max-width: 30%;
+  margin: 0 auto;
+}

--- a/src/components/PageWrapper/page-wrapper.css
+++ b/src/components/PageWrapper/page-wrapper.css
@@ -4,7 +4,7 @@
     #76dd78 -18.28%,
     rgba(118, 221, 120, 0.15) 63.69%
   );
-  height: 100vh;
+  min-height: 100vh;
 }
 
 .wrapper {
@@ -15,7 +15,7 @@
   border-radius: 50px;
   max-width: 600px;
   width: 50%;
-  height: 80vh;
+  min-height: 80vh;
   margin: 0 auto;
   padding: 20px;
 }

--- a/src/components/PageWrapper/page-wrapper.css
+++ b/src/components/PageWrapper/page-wrapper.css
@@ -1,5 +1,32 @@
+.green-bg {
+  background: linear-gradient(
+    128.9deg,
+    #76dd78 -18.28%,
+    rgba(118, 221, 120, 0.15) 63.69%
+  );
+  height: 100vh;
+}
+
 .wrapper {
-  border: 1px solid;
-  max-width: 30%;
+  background: #ffffff;
+  border: 1px solid #ffffff;
+  box-sizing: border-box;
+  box-shadow: 0px 4px 26px rgba(0, 0, 0, 0.17);
+  border-radius: 50px;
+  max-width: 600px;
+  width: 50%;
+  height: 80vh;
   margin: 0 auto;
+  padding: 20px;
+}
+
+@media only screen and (max-width: 768px) {
+  .green-bg {
+    background: #fff;
+  }
+  .wrapper {
+    width: 100%;
+    border-radius: 0;
+    box-shadow: none;
+  }
 }

--- a/src/components/PageWrapper/page-wrapper.css
+++ b/src/components/PageWrapper/page-wrapper.css
@@ -11,7 +11,7 @@
   background: #ffffff;
   border: 1px solid #ffffff;
   box-sizing: border-box;
-  box-shadow: 0px 4px 26px rgba(0, 0, 0, 0.17);
+  box-shadow: 0px 4px 24px rgba(0, 0, 0, 0.17);
   border-radius: 50px;
   max-width: 600px;
   width: 50%;

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  font-size: 16px;
 }
 
 code {

--- a/src/pages/AddItemView.jsx
+++ b/src/pages/AddItemView.jsx
@@ -5,6 +5,7 @@ import AddItemForm from '../components/AddItemForm';
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import moment from 'moment';
+import { PageWrapper } from '../components/PageWrapper/PageWrapper';
 
 export const AddItemView = ({ token }) => {
   const [inputs, setInputs] = useState({
@@ -63,7 +64,7 @@ export const AddItemView = ({ token }) => {
   };
 
   return (
-    <div>
+    <PageWrapper>
       <h1>Smart Shopping List</h1>
       <AddItemForm
         handleChange={handleChange}
@@ -71,6 +72,6 @@ export const AddItemView = ({ token }) => {
         inputs={inputs}
       />
       <ToastContainer />
-    </div>
+    </PageWrapper>
   );
 };

--- a/src/pages/ListView.jsx
+++ b/src/pages/ListView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { List } from '../components/List/List';
 import { useNavigate } from 'react-router-dom';
+import { PageWrapper } from '../components/PageWrapper/PageWrapper';
 
 export const ListView = ({ token }) => {
   let navigate = useNavigate();
@@ -10,7 +11,7 @@ export const ListView = ({ token }) => {
   }
 
   return (
-    <div>
+    <PageWrapper>
       {token ? (
         <List token={token} />
       ) : (
@@ -18,6 +19,6 @@ export const ListView = ({ token }) => {
           Go back to Home
         </button>
       )}
-    </div>
+    </PageWrapper>
   );
 };


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

In this PR, I created a component `PageWrapper.jsx` that wraps around `ListView.jsx` and `AddItemView.jsx` to give both pages a green gradient background with the content inside a white rounded box. I styled the component and made it mobile responsive in `page-wrapper.css`. 

Currently, the navigation is not included in the wrapper, but I am assuming that the navigation will be moved inside `ListView.jsx` and `AddItemView.jsx` in a different PR. Once it's been moved, the navigation should also have the green gradient behind it. 

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->
closes #36 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|     | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### The Design

<!-- If UI feature, take provide screenshots -->

![image](https://user-images.githubusercontent.com/46573212/155802066-d28fc10a-53ef-48d6-bde4-095d56a38ab4.png)


### After

<!-- If UI feature, take provide screenshots -->

![image](https://user-images.githubusercontent.com/46573212/155802185-82c3bcc2-f362-483b-8d74-8c2ae33caec6.png)

