### PR TITLE
Add Protected Routes for /add and /list

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AddItemView } from './pages/AddItemView';
 import { ListView } from './pages/ListView';
 import { Home } from './pages/Home';
+import RequireToken from '../src/components/RequireToken';
 import { RouteLink } from './components/RouteLink';
 import './App.css';
 
@@ -27,11 +28,19 @@ function App() {
           <Route
             exact
             path="/list"
-            element={<ListView token={token} setToken={setToken} />}
+            element={
+              <RequireToken token={token}>
+                <ListView token={token} setToken={setToken} />
+              </RequireToken>
+            }
           />
           <Route
             path="/add"
-            element={<AddItemView token={token} setToken={setToken} />}
+            element={
+              <RequireToken token={token}>
+                <AddItemView token={token} setToken={setToken} />
+              </RequireToken>
+            }
           />
         </Routes>
         <nav className="footer">

--- a/src/App.js
+++ b/src/App.js
@@ -29,7 +29,7 @@ function App() {
             exact
             path="/list"
             element={
-              <RequireToken token={token}>
+              <RequireToken>
                 <ListView token={token} setToken={setToken} />
               </RequireToken>
             }
@@ -37,7 +37,7 @@ function App() {
           <Route
             path="/add"
             element={
-              <RequireToken token={token}>
+              <RequireToken>
                 <AddItemView token={token} setToken={setToken} />
               </RequireToken>
             }

--- a/src/components/RequireToken.jsx
+++ b/src/components/RequireToken.jsx
@@ -1,0 +1,12 @@
+import { useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
+
+const RequireToken = ({ children }) => {
+  const navigate = useNavigate();
+  useEffect(() => {
+    if (!localStorage.getItem('token')) navigate('/');
+  }, [navigate]);
+  return children;
+};
+
+export default RequireToken;


### PR DESCRIPTION
## Description

This PR adds protected routes to `App.js`, which check if a user has a token stored in localStorage before allowing them to access the /add and /list routes. If no token exists, the user is instantly redirected to the homepage where they can create a token or sign in using an existing one.

## Related Issue

Closes #47 

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓   | :sparkles: New feature     |

## Testing Steps / QA Criteria

1. `npm start`
2. Sign out (or remove token from localStorage) and attempt to navigate to `localhost:3000/list` or `localhost:3000/add` via the URL bar
     - You should be redirected to the homepage
3. Create a new list or sign in with existing token - use URL bar and/or nav to visit `/add` or `/list` routes
     - You should be able to access them as normal
