### PR TITLE
Add Open Graph metadata to html head

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,6 +28,23 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>SmartShopperr</title>
+    <meta name="description" content="Smart Shopping List" />
+    <meta name="title" property="og:title" content="SmartShopperr" />
+    <meta property="og:type" content="website" />
+    <meta
+      name="image"
+      property="og:image"
+      content="https://live.staticflickr.com/65535/51929581887_671e8430e4_k.jpg"
+    />
+    <meta
+      name="description"
+      property="og:description"
+      content="Smart Shopping List"
+    />
+    <meta
+      name="author"
+      content="Dana Pughakoff, Viviana Davila, Rafael Brown"
+    />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Description

This PR adds metadata to the public HTML file using the Open Graph protocol. I followed [this tutorial](https://medium.com/@jamesyhiggs/how-to-add-thumbnail-images-to-the-featured-section-of-your-linkedin-profile-for-web-apps-sites-917346235932).

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |

## Thumbnail Used

<img width="943" alt="smartshopperr-thumbnail" src="https://user-images.githubusercontent.com/82783679/157754141-88163d96-157f-4430-abe5-e743a07708a2.png">

